### PR TITLE
Fix pyproject.toml not found error

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -27,11 +27,11 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv pip install -r pyproject.toml --extra docs
+          uv pip install -e .[docs]
 
       - name: Build documentation
         run: |
-          uv run mkdocs build
+          mkdocs build
 
       - name: Deploy to GitHub Pages
         if: github.ref == 'refs/heads/main'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,49 @@
+[build-system]
+requires = ["setuptools>=45", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "myfinance"
+version = "0.1.0"
+description = "Sistema de finanças pessoais"
+requires-python = ">=3.11,<3.13"
+dependencies = []
+
+[project.optional-dependencies]
+backend = [
+    "fastapi==0.104.1",
+    "uvicorn[standard]==0.24.0",
+    "supabase==2.0.2",
+    "psycopg2-binary==2.9.9",
+    "sqlalchemy==2.0.23",
+    "alembic==1.13.1",
+    "pydantic==2.5.3"
+]
+docs = [
+    "mkdocs",
+    "mkdocs-material",
+    "mkdocs-git-revision-date-localized-plugin"
+]
+dev = [
+    "invoke"
+]
+test = [
+    "pytest",
+    "httpx",
+    "pytest-cov"
+]
+security = [
+    "safety"
+] 
+quality = [
+    "ruff",
+    "radon",
+    "bandit"
+]
+
+[tool.pytest.ini_options]
+addopts = "--cov=src --cov-report=term-missing" 
+
+[tool.coverage.run]
+relative_files = true 
+source = ["src"]


### PR DESCRIPTION
Fix build-docs pipeline by restoring `pyproject.toml` and correcting `uv` dependency installation commands.

---

[Open in Web](https://cursor.com/agents?id=bc-9cd4c36e-5bcf-4315-8ce2-18d2a71900c2) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-9cd4c36e-5bcf-4315-8ce2-18d2a71900c2) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)