### PR TITLE
hotfix: Fix deploy docs permissions

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:  # Permite execução manual
 
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 


### PR DESCRIPTION
Elevate contents permission to write for GitHub Pages deployment to resolve 'Resource not accessible by integration' error.