### PR TITLE
hotfix: Explicitly grant permissions for Pages deployment in private repo

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -17,6 +17,10 @@ permissions:
 jobs:
   build-docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Add job-level permissions for 'build-docs' job to ensure proper GitHub Pages deployment in private repositories.