### PR TITLE
hotfix: Fix deploy trigger for private repositories

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -3,7 +3,6 @@ name: Deploy Documentation
 on:
   push:
     branches: [ main, develop, feature/deploy-gratuito ]
-    paths: [ 'docs/**', 'mkdocs.yml' ]
   pull_request:
     branches: [ main ]
     paths: [ 'docs/**', 'mkdocs.yml' ]


### PR DESCRIPTION
Remove paths filter from push trigger for main branch to ensure workflow is always triggered on merge.