### PR TITLE
hotfix(migrations):      Remove foreign key to auth.users in categories table

### DIFF
--- a/alembic/versions/b2f5g4h6i1j3_add_categories_table.py
+++ b/alembic/versions/b2f5g4h6i1j3_add_categories_table.py
@@ -29,7 +29,7 @@ def upgrade():
     sa.Column('is_active', sa.Boolean(), nullable=True),
     sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=True),
     sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=True),
-    sa.ForeignKeyConstraint(['user_id'], ['auth.users'], ),
+    
     sa.PrimaryKeyConstraint('id'),
     sa.UniqueConstraint('user_id', 'name')
     )


### PR DESCRIPTION
Remove a chave estrangeira para 'auth.users' na tabela      'categories' para resolver o erro 'UndefinedTable' durante as     migrações, já que 'auth.users' é gerenciado externamente.