### PR TITLE
hotfix(migrations): Remove duplicate category_id column      management

### DIFF
--- a/alembic/versions/49c69a18767d_add_category_id_to_transactions_table.py
+++ b/alembic/versions/49c69a18767d_add_category_id_to_transactions_table.py
@@ -54,6 +54,6 @@ def downgrade() -> None:
                existing_type=sa.UUID(),
                server_default=sa.text('gen_random_uuid()'),
                existing_nullable=False)
-    op.drop_column('transactions', 'category_id')
+    
     
     # ### end Alembic commands ### 


### PR DESCRIPTION
Remove o gerenciamento duplicado da      coluna 'category_id' na tabela 'transactions' para resolver o     erro 'DuplicateColumn' durante as migrações.